### PR TITLE
Use /usr/bin/env rather than hardcoded ruby path

### DIFF
--- a/bin/scottkit
+++ b/bin/scottkit
@@ -1,4 +1,5 @@
-#!/usr/local/bin/ruby -w
+#!/usr/bin/env ruby
+$VERBOSE = true
 
 # Command-line driver for the ScottKit toolkit, allowing Scott
 # Adams-format adventure games to be compiled, decompiled and played.


### PR DESCRIPTION
I'm using ruby built with ruby-build and rbenv so it's not in `/usr/local/bin` my understanding is this is the right way to specify it now.

```
andrew:~/projects/scottkit (master)% ./bin/scottkit 
./bin/scottkit: Command not found.
andrew:~/projects/scottkit (master)% which ruby
/Users/andrew/.rbenv/shims/ruby
andrew:~/projects/scottkit (master)% ruby ./bin/scottkit 
./bin/scottkit: No data-file specified
Usage: ./bin/scottkit [options] [<data-file>]
(ScottKit version 1.5.0)
[...]
andrew:~/projects/scottkit (master)% git checkout shebang
Switched to branch 'shebang'
Your branch is up-to-date with 'origin/shebang'.
andrew:~/projects/scottkit (shebang)% ./bin/scottkit
./bin/scottkit: No data-file specified
Usage: ./bin/scottkit [options] [<data-file>]
(ScottKit version 1.5.0)
[...]
```