### PR TITLE
Add support for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+dist: trusty
+language: ruby
+rvm:
+- 2.0
+- 2.1
+- 2.2
+- 2.3
+- 2.4
+cache: bundler

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+source "https://rubygems.org"
+
+gem "rake", "~> 12.0"
+gem "jeweler", "~> 2.0"
+gem "test-unit", "~> 3.2.0"

--- a/Rakefile
+++ b/Rakefile
@@ -39,8 +39,6 @@ rescue LoadError
   end
 end
 
-task :test => :check_dependencies
-
 task :default => :test
 
 require 'rdoc/task'


### PR DESCRIPTION
Requires a Gemfile to get the dependencies installed. I'm at least seeing where the gem config lives now. You can see the results of this branch running in my repo: https://travis-ci.org/drewish/scottkit/builds/291264479

Fixes #12 (once you enable it on your repo ;))